### PR TITLE
Connect Registered Users w/Zero Solves

### DIFF
--- a/crypto.py
+++ b/crypto.py
@@ -28,8 +28,9 @@ class Score:
         assert len(spl) == 7
         if spl[1] is 'None':
             spl[1] = spl[-1]
+            spl[2], spl[4] = '0', '0'
         username = spl.pop(0)
-        return cls(*([username] + list(map(int, [value if value.isdigit() else '0' for value in spl]))))
+        return cls(*([username] + list(map(int, spl))))
 
 def get_userscore(username):
     response = requests.get(f"{config.api.base}{config.api.userscore_endpoint}", params={"authkey": config.api.authkey, "username": username}).text

--- a/crypto.py
+++ b/crypto.py
@@ -26,8 +26,10 @@ class Score:
         #username:global_rank:points:total_points:challs_solved:total_challs:num_users
         spl = raw.split(":")
         assert len(spl) == 7
+        if spl[1] is 'None':
+            spl[1] = spl[-1]
         username = spl.pop(0)
-        return cls(*([username] + list(map(int, spl))))
+        return cls(*([username] + list(map(int, [value if value.isdigit() else '0' for value in spl]))))
 
 def get_userscore(username):
     response = requests.get(f"{config.api.base}{config.api.userscore_endpoint}", params={"authkey": config.api.authkey, "username": username}).text


### PR DESCRIPTION
Connect Registered Users w/Zero Solves

The CryptoHack API returns user score values of 'None' when the user has not yet solved any challenges. The bot has been taking exception to score values that are not strings of digits, and failing to connect new users. Now, the bot will connect new users even if they have not yet solved any challenges.